### PR TITLE
Milestones in correct order

### DIFF
--- a/app/Http/Controllers/MilestoneController.php
+++ b/app/Http/Controllers/MilestoneController.php
@@ -69,25 +69,28 @@ class MilestoneController extends Controller {
 		$milestone = Milestone::findOrFail($milestoneId);
 		$attrs = $request->all();
 
-		$old_next_milestone = Project::findOrFail($request['project_id'])->next_milestone($milestone->id);
-
-		$old_prev_milestone = Milestone::find($milestone->previous_milestone_id);
-
-		// get the updated milestone's new previous milestone
-		$prev_milestone = Milestone::findOrFail($request['previous_milestone_id']);
-
-		// update the milestone that currently has $prev_milestone as its next milestone // 3
-		Project::findOrFail($request['project_id'])->next_milestone($prev_milestone->id)->update(array('previous_milestone_id' => $milestone->id));
-
-		if($old_next_milestone)
+		if($request['previous_milestone_id'] != $milestone->previous_milestone_id)
 		{
-			if($old_prev_milestone)
+			$old_next_milestone = Project::findOrFail($request['project_id'])->next_milestone($milestone->id);
+
+			$old_prev_milestone = Milestone::find($milestone->previous_milestone_id);
+
+			// get the updated milestone's new previous milestone
+			$prev_milestone = Milestone::findOrFail($request['previous_milestone_id']);
+
+			// update the milestone that currently has $prev_milestone as its next milestone // 3
+			Project::findOrFail($request['project_id'])->next_milestone($prev_milestone->id)->update(array('previous_milestone_id' => $milestone->id));
+
+			if($old_next_milestone)
 			{
-				$old_next_milestone->update(array('previous_milestone_id' => $old_prev_milestone->id));
-			}
-			else
-			{
-				$old_next_milestone->update(array('previous_milestone_id' => null));
+				if($old_prev_milestone)
+				{
+					$old_next_milestone->update(array('previous_milestone_id' => $old_prev_milestone->id));
+				}
+				else
+				{
+					$old_next_milestone->update(array('previous_milestone_id' => null));
+				}
 			}
 		}
 

--- a/app/Http/Controllers/MilestoneController.php
+++ b/app/Http/Controllers/MilestoneController.php
@@ -76,10 +76,15 @@ class MilestoneController extends Controller {
 			$old_prev_milestone = Milestone::find($milestone->previous_milestone_id);
 
 			// get the updated milestone's new previous milestone
-			$prev_milestone = Milestone::findOrFail($request['previous_milestone_id']);
+			$new_prev_milestone = Milestone::findOrFail($request['previous_milestone_id']);
 
-			// update the milestone that currently has $prev_milestone as its next milestone // 3
-			Project::findOrFail($request['project_id'])->next_milestone($prev_milestone->id)->update(array('previous_milestone_id' => $milestone->id));
+			// update the milestone that comes after the new prev milestone
+			$milestone_after_new_prev = Project::find($request['project_id'])->next_milestone($new_prev_milestone->id);
+
+			if($milestone_after_new_prev)
+			{
+				$milestone_after_new_prev->update(array('previous_milestone_id' => $milestone->id));
+			}
 
 			if($old_next_milestone)
 			{

--- a/app/Project.php
+++ b/app/Project.php
@@ -46,6 +46,16 @@ class Project extends Model {
 		return $this->hasMany('App\Milestone');
 	}
 
+	public function first_milestone() {
+		return $this->milestones()
+			->where('previous_milestone_id', null)->first();
+	}
+
+	public function next_milestone(int $milestone_id) {
+		return $this->milestones()
+			->where('previous_milestone_id', $milestone_id)->first();
+	}
+
 	public function suppliers() {
 		return $this->belongsToMany('App\User', 'project_user', 'project_id', 'user_id')
 			->withPivot('accepted')

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -111,8 +111,10 @@
 				</div>
 				@if(count($project->milestones) > 0)
 					<div class="ui list milestone-section">
-					@foreach ($project->milestones as $milestone)
-
+					@for($i = 1; $i <= count($project->milestones); $i++)
+						@php
+							$milestone = $i > 1 ?  $project->next_milestone($milestone->id) : $project->first_milestone();
+						@endphp
 						@switch($milestone->status)
 						@case(Config::get('enum.milestone_status')['done'])
 						<div class="item done">
@@ -143,7 +145,7 @@
 							</div>
 						</div>
 						@endswitch
-					@endforeach
+					@endfor
 					</div>
 				@endif
 			</div>

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -11,9 +11,13 @@
 		</tr>
 	</thead>
 	<tbody id="milestoneList">
-		@foreach($project->milestones as $milestone)
-		<tr data-index="{{ $loop->iteration }}">
-			<td>{{ $loop->iteration }}</td>
+		@for($i = 1; $i <= count($project->milestones); $i++)
+		<tr data-index="{{ $i }}">
+			<td>{{ $i }}</td>
+			@php
+				$milestone = $i > 1 ?  $project->next_milestone($milestone->id) : $project->first_milestone();
+			@endphp
+			@if(isset($milestone))
 			<td class="name">{{ $milestone->name }}</td>
 			<td class="status">
 				@switch($milestone->status)
@@ -33,8 +37,9 @@
 			<td class="buttons">
 				<button data-id="{{ $milestone->id }}" class="ui button primary milestoneEditBtn">Edit</button>
 			</td>
+			@endif
 		</tr>
-		@endforeach
+		@endfor
 	</tbody>
 </table>
 
@@ -189,10 +194,8 @@
 					addMilestone(data);
 				}
 			},
-			error: function (xhr, status) {
-				console.log(values);
-				console.error(status);
-				console.error(xhr);
+			error: function (data) {
+				console.log(data);
 				// TODO: Let's be more specific about this
 				alert(`Uh oh! Something went wrong and we couldn't ${isEdit ? "save": "create"} your milestone. Please try again later.`);
 			},


### PR DESCRIPTION
## Changes
- Milestones are presented in order (according to the previous milestone).
- Update milestones changes the affected milestones instead of only the milestone being updated.
- Changes in front end are shown on the `progress bar list` and the `milestones tab`.

## Considered test cases:
Create and update of:
- the last milestone
- and intermediary milestone
- the first milestone (update only)